### PR TITLE
Version bump to 1.0.7 - Kaiju binary and database updates

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### Version 1.0.7
+__Changes__
+- renamed kaijuReport binary to kaiju2table
+- updated Kaiju reference databases; now using 2019-06-25 versions
+
 ### Version 1.0.6
 __Changes__
 - update docs

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,10 @@
 ### Version 1.0.7
 __Changes__
-- renamed kaijuReport binary to kaiju2table
 - updated Kaiju reference databases; now using 2019-06-25 versions
+- added new required flags -i and -j to kaiju binary
+- renamed kaijuReport binary to kaiju2table
+- removed discontinued flag -i from kaiju2table
+- addressed new kaiju database directory structure
 
 ### Version 1.0.6
 __Changes__

--- a/kb_kaiju.spec
+++ b/kb_kaiju.spec
@@ -5,7 +5,7 @@ determines taxonomic structure for microbial communities from shotgun metagenomi
 
 Module also utilizes Krona for visualization of results
 
-References: 
+References:
 Kaiju Homepage: http://kaiju.binf.ku.dk/
 Krona Homepage: https://github.com/marbl/Krona/wiki
 Kaiju DBs from: http://kaiju.binf.ku.dk/server
@@ -33,7 +33,7 @@ module kb_kaiju {
     */
     typedef int bool;
 
-    /* 
+    /*
     ** The workspace object refs are of form:
     **
     **    objects = ws.get_objects([{'ref': params['workspace_id']+'/'+params['obj_name']}])
@@ -47,15 +47,15 @@ module kb_kaiju {
     typedef string data_obj_ref;
 
 
-    /*  
+    /*
         kaiju command line:
 	===================
 	kaiju -t nodes.dmp -f kaiju_db.fmi -i inputfile.fastq  (for single-end libraries)
 	kaiju -t nodes.dmp -f kaiju_db.fmi -i fwd_file.fastq -j rev_file.fastq  (for paired-end libraries)
-	
+
 	-o <output_file>
 	-z <thread_count>                (e.g. 4)
-	
+
 	default run mode is MEM          (only consider exact matches)
 	-a greedy -e <num_substitutions> (Greedy run mode permits <e> mismatches)
 	-m <minimum_match_length>        (default: 11)
@@ -67,9 +67,9 @@ module kb_kaiju {
 	-p                               (disable translation of input sequences to protein)
 	-x                               (filter low-complexity regions with SEG - recommended)
 
-	kaijuReport command line:
+	kaiju2table command line:
 	=========================
-	kaijuReport -t nodes.dmp -n names.dmp -i kaiju.out -r genus -o kaiju.out.summary
+	kaiju2table -t nodes.dmp -n names.dmp -i kaiju.out -r genus -o kaiju.out.summary
 
 	-m <percent>                     (filter out members that are < percent of total reads)
 	-m -u                            (filter out members that are < percent of all classified reads)

--- a/kb_kaiju.spec
+++ b/kb_kaiju.spec
@@ -50,8 +50,8 @@ module kb_kaiju {
     /*
         kaiju command line:
 	===================
-	kaiju -t nodes.dmp -f kaiju_db.fmi -i inputfile.fastq  (for single-end libraries)
-	kaiju -t nodes.dmp -f kaiju_db.fmi -i fwd_file.fastq -j rev_file.fastq  (for paired-end libraries)
+	kaiju -t nodes.dmp -f kaiju_db_refseq.fmi -i inputfile.fastq  (for single-end libraries)
+	kaiju -t nodes.dmp -f kaiju_db_refseq.fmi -i fwd_file.fastq -j rev_file.fastq  (for paired-end libraries)
 
 	-o <output_file>
 	-z <thread_count>                (e.g. 4)

--- a/kb_kaiju.spec
+++ b/kb_kaiju.spec
@@ -69,15 +69,15 @@ module kb_kaiju {
 
 	kaiju2table command line:
 	=========================
-	kaiju2table -t nodes.dmp -n names.dmp -i kaiju.out -r genus -o kaiju.out.summary
+	kaiju2table -t nodes.dmp -n names.dmp -r genus -o kaiju.out.summary kaiju.out
 
 	-m <percent>                     (filter out members that are < percent of total reads)
 	-m -u                            (filter out members that are < percent of all classified reads)
 	-p                               (full taxon path instead of just taxon name)
 
-	addTaxonNames command line:
+	kaiju-addTaxonNames command line:
 	===========================
-	addTaxonNames -t nodes.dmp -n names.dmp -i kaiju.out -o kaiju.names.out
+	kaiju-addTaxonNames -t nodes.dmp -n names.dmp -i kaiju.out -o kaiju.names.out
 	-u                               (omit unclassified reads)
 	-p                               (print the full taxon path instead of just the taxon name)
 	-r <class1>[,<class2>,...]       (print the path containing only to the specified ranks. e.g. "-r phylum,genus")

--- a/kbase.yml
+++ b/kbase.yml
@@ -11,7 +11,7 @@ module-version:
     1.0.6
 
 owners:
-    [dylan]
+    [dylan, seanjungbluth]
 
 data-version:
     1.0

--- a/lib/kb_kaiju/Utils/KaijuUtil.py
+++ b/lib/kb_kaiju/Utils/KaijuUtil.py
@@ -33,7 +33,7 @@ class KaijuUtil:
 
         if not os.path.exists(self.scratch):
             os.makedirs(self.scratch)
-        
+
 
     def run_kaiju_with_krona(self, params):
         '''
@@ -244,14 +244,14 @@ class KaijuUtil:
 
     def run_proc(self, command, log_output_file=None):
         log('Running: ' + ' '.join(command))
-        
+
         if log_output_file:  # if output is too chatty for STDOUT
             open (log_output_file, 'w')
             p = subprocess.Popen(command, cwd=self.scratch, shell=False, stdout=log_output_file, stderr=subprocess.STDOUT)
         else:
             p = subprocess.Popen(command, cwd=self.scratch, shell=False)
         exitCode = p.wait()
-            
+
         if log_output_file:
             log_output_file.close()
 
@@ -262,7 +262,7 @@ class KaijuUtil:
             raise ValueError('Error running command: ' + ' '.join(command) + '\n' +
                              'Exit Code: ' + str(exitCode))
         return exitCode
-            
+
 
     def validate_run_kaiju_with_krona_params(self, params):
         method = 'run_kaiju_with_krona'
@@ -336,7 +336,7 @@ class KaijuUtil:
                     bad_vals_msgs.append('Value greater than maximum for parameter '+arg+' ('+str(param[arg])+' > '+str(limit_vals[arg]['max']))
         if len(bad_vals_msgs) > 0:
             raise ValueError ("\n".join(bad_vals_msgs)+"\n")
-                    
+
         # return adjusted params
         return params
 
@@ -348,10 +348,10 @@ class KaijuUtil:
         for input_reads_item in input_reads:
 
             # download and subsample reads
-            staged_input = self.dsu_client.stage_input(input_item =           input_reads_item, 
-                                                       subsample_percent =    int(options['subsample_percent']), 
-                                                       subsample_replicates = int(options['subsample_replicates']), 
-                                                       subsample_seed =       int(options['subsample_seed']), 
+            staged_input = self.dsu_client.stage_input(input_item =           input_reads_item,
+                                                       subsample_percent =    int(options['subsample_percent']),
+                                                       subsample_replicates = int(options['subsample_replicates']),
+                                                       subsample_seed =       int(options['subsample_seed']),
                                                        fasta_file_extension = 'fastq')
             #input_dir = staged_input['input_dir']
             replicate_input = staged_input['replicate_input']
@@ -367,7 +367,7 @@ class KaijuUtil:
                 log_output_file = None
                 if dropOutput:  # if output is too chatty for STDOUT
                     log_output_file = os.path.join(self.scratch, input_reads_item['name'] + '.kaiju' + '.stdout')
-            
+
                 command = self._build_kaiju_command(single_kaiju_run_options)
                 self.run_proc (command, log_output_file)
 
@@ -386,11 +386,11 @@ class KaijuUtil:
                 single_kaijuReport_run_options = options
                 single_kaijuReport_run_options['input_item'] = input_reads_item
                 single_kaijuReport_run_options['tax_level'] = tax_level
-            
+
                 log_output_file = None
                 if dropOutput:  # if output is too chatty for STDOUT
                     log_output_file = os.path.join(self.scratch, input_reads_item['name'] + '.kaijuReport' + '.stdout')
-            
+
                 command = self._build_kaijuReport_command(single_kaijuReport_run_options)
                 self.run_proc (command, log_output_file)
 
@@ -410,7 +410,7 @@ class KaijuUtil:
                     single_kaijuReportPlots_options = options
                     single_kaijuReportPlots_options['input_item'] = input_reads_item
                     single_kaijuReportPlots_options['tax_level'] = tax_level
-            
+
                     per_sample_plot_files[tax_level][input_reads['name']] = self.outputBuilder_client.generate_kaijuReport_PerSamplePlots(single_kaijuReportPlots_options)
 
             # stacked bar plots
@@ -438,23 +438,23 @@ class KaijuUtil:
     def run_kaijuReportPlotsHTML_batch(self, options):
         out_html_folder = options['out_folder']
         out_html_files = dict()
-            
+
         if 'stacked_bar_plot_files' in options:
             out_html_files['bar'] = self.outputBuilder_client.build_html_for_kaijuReport_StackedPlots(
                 options['input_reads'],
                 options['summary_folder'],
                 out_html_folder,
-                'bar', 
+                'bar',
                 options['tax_levels'],
                 options['stacked_bar_plot_files']
             )
-                                  
+
         if 'stacked_area_plot_files' in options:
             out_html_files['area'] = self.outputBuilder_client.build_html_for_kaijuReport_StackedPlots(
                 options['input_reads'],
                 options['summary_folder'],
                 out_html_folder,
-                'area', 
+                'area',
                 options['tax_levels'],
                 options['stacked_area_plot_files']
             )
@@ -469,7 +469,7 @@ class KaijuUtil:
             )
 
         return out_html_files
-                                  
+
 
     def run_krona_batch(self, options, dropOutput=False):
         out_html_files = []
@@ -483,7 +483,7 @@ class KaijuUtil:
             log_output_file = None
             if dropOutput:  # if output is too chatty for STDOUT
                 log_output_file = os.path.join(self.scratch, input_reads_item['name'] + '.kaiju2krona' + '.stdout')
-            
+
             command = self._build_kaiju2krona_command(single_kaiju2krona_run_options)
             self.run_proc (command, log_output_file)
 
@@ -494,7 +494,7 @@ class KaijuUtil:
             log_output_file = None
             if dropOutput:  # if output is too chatty for STDOUT
                 log_output_file = os.path.join(self.scratch, input_reads_item['name'] + '.kronaImport' + '.stdout')
-            
+
             command = self._build_kronaImport_command(single_kronaImport_run_options)
             self.run_proc (command, log_output_file)
 
@@ -583,7 +583,7 @@ class KaijuUtil:
             command_list.append(str(options.get('threads')))
         if options.get('verbose'):
             command_list.append('-v')
-        
+
 
     def _build_kaiju_command(self, options, verbose=True):
         KAIJU_BIN_DIR  = os.path.join(os.path.sep, 'kb', 'module', 'kaiju', 'bin')
@@ -614,7 +614,7 @@ class KaijuUtil:
 
     def _validate_kaijuReport_options(self, options):
         # 1st order required
-        func_name = 'kaijuReport'
+        func_name = 'kaiju2table'
         required_opts = [ 'in_folder',
                           'input_item',
                           'out_folder',
@@ -646,7 +646,7 @@ class KaijuUtil:
         if options.get('KAIJU_DB_NAMES'):
             command_list.append('-n')
             command_list.append(str(options.get('KAIJU_DB_NAMES')))
-        if options.get('in_folder'):
+        if options.get('in_folder'): #might need changes here?
             in_file = options['input_item']['name']+'.kaiju'
             in_path = os.path.join(options['in_folder'], in_file)
             command_list.append('-i')
@@ -666,11 +666,11 @@ class KaijuUtil:
             command_list.append('-u')
         if int(options.get('full_tax_path')) == 1:
             command_list.append('-p')
-        
+
 
     def _build_kaijuReport_command(self, options):
         KAIJU_BIN_DIR    = os.path.join(os.path.sep, 'kb', 'module', 'kaiju', 'bin')
-        KAIJU_REPORT_BIN = os.path.join(KAIJU_BIN_DIR, 'kaijuReport')
+        KAIJU_REPORT_BIN = os.path.join(KAIJU_BIN_DIR, 'kaiju2table')
         KAIJU_DB_DIR     = os.path.join(os.path.sep, 'data', 'kaijudb', options['db_type'])
 
         options['KAIJU_DB_NODES'] = os.path.join(KAIJU_DB_DIR, 'nodes.dmp')
@@ -725,7 +725,7 @@ class KaijuUtil:
             out_path = os.path.join (str(options.get('out_folder')), out_file)
             command_list.append('-o')
             command_list.append(out_path)
-        
+
 
     def _build_kaiju2krona_command(self, options):
         KAIJU_BIN_DIR     = os.path.join(os.path.sep, 'kb', 'module', 'kaiju', 'bin')
@@ -769,7 +769,7 @@ class KaijuUtil:
             in_file = options['input_item']['name']+'.krona'
             in_path = os.path.join(options['out_folder'], in_file)
             command_list.append(in_path)
-        
+
 
     def _build_kronaImport_command(self, options):
         KRONA_BIN_DIR    = os.path.join(os.path.sep, 'usr', 'local', 'bin')

--- a/lib/kb_kaiju/Utils/KaijuUtil.py
+++ b/lib/kb_kaiju/Utils/KaijuUtil.py
@@ -595,16 +595,16 @@ class KaijuUtil:
             options['threads'] = self.threads
         options['KAIJU_DB_NODES'] = os.path.join(KAIJU_DB_DIR, 'nodes.dmp')
         #options['KAIJU_DB_NAMES'] = os.path.join(KAIJU_DB_DIR, 'names.dmp')  # don't need for kaiju cmd
-        if options['db_type'] == 'kaiju_index':
-            options['KAIJU_DB_PATH'] = os.path.join(KAIJU_DB_DIR, 'kaiju_db.fmi')
-        elif options['db_type'] == 'kaiju_index_pg':
-            options['KAIJU_DB_PATH'] = os.path.join(KAIJU_DB_DIR, 'kaiju_db.fmi')
-        elif options['db_type'] == 'kaiju_index_nr':
+        if options['db_type'] == 'refseq':
+            options['KAIJU_DB_PATH'] = os.path.join(KAIJU_DB_DIR, 'kaiju_db_refseq.fmi')
+        elif options['db_type'] == 'progenomes':
+            options['KAIJU_DB_PATH'] = os.path.join(KAIJU_DB_DIR, 'kaiju_db_progenomes.fmi')
+        elif options['db_type'] == 'nr':
             options['KAIJU_DB_PATH'] = os.path.join(KAIJU_DB_DIR, 'kaiju_db_nr.fmi')
-        elif options['db_type'] == 'kaiju_index_nr_euk':
+        elif options['db_type'] == 'nr_euk':
             options['KAIJU_DB_PATH'] = os.path.join(KAIJU_DB_DIR, 'kaiju_db_nr_euk.fmi')
         else:
-            raise ValueError ('bad db_type: '+options['db_type']+' (must be one of "kaiju_index", "kaiju_index_pg", "kaiju_index_nr", "kaiju_index_nr_euk")')
+            raise ValueError ('bad db_type: '+options['db_type']+' (must be one of "refseq", "progenomes", "nr", "nr_euk")')
 
         self._validate_kaiju_options(options)
         command = [KAIJU_BIN]

--- a/lib/kb_kaiju/Utils/OutputBuilder.py
+++ b/lib/kb_kaiju/Utils/OutputBuilder.py
@@ -193,8 +193,8 @@ class OutputBuilder(object):
                 'name': zip_file_name,
                 'label': zip_file_description}
 
-        
-    def generate_sparse_biom1_0_matrix(self, ctx, options): 
+
+    def generate_sparse_biom1_0_matrix(self, ctx, options):
         tax_level       = options['tax_level']
         db_type         = options['db_type']
         input_reads     = options['input_reads']
@@ -248,7 +248,7 @@ class OutputBuilder(object):
         timestamp_iso = dt.fromtimestamp(timestamp_epoch,pytz.utc).strftime('%Y-%m-%d'+'T'+'%H:%M:%S')
         for lineage_name in lineage_order:
             # KBase BIOM typedef only supports string, not dict.  This is wrong (see format_url below)
-            #rows_struct.append({'id': lineage_name, 'metadata': None})  # could add metadata full tax path if parsed from KaijuReport
+            #rows_struct.append({'id': lineage_name, 'metadata': None})  # could add metadata full tax path if parsed from kaiju2table
             rows_struct.append(lineage_name)
         for sample_name in sample_order:
             # KBase BIOM typedef only supports string, not dict.  This is wrong (see format_url below)
@@ -272,7 +272,7 @@ class OutputBuilder(object):
         # extra KBase BIOM obj required fields that aren't part of biom-1.0 spec (probably custom to MG-RAST)
         biom_obj['url'] = None
         biom_obj['matrix_element_value'] = None
-        
+
 
         # save the biom obj to workspace
         provenance = [{}]
@@ -302,7 +302,7 @@ class OutputBuilder(object):
                                                          'meta': {},
                                                          'provenance': provenance
                                                      }]
-                                               })[0]        
+                                               })[0]
         [OBJID_I, NAME_I, TYPE_I, SAVE_DATE_I, VERSION_I, SAVED_BY_I, WSID_I, WORKSPACE_I, CHSUM_I, SIZE_I, META_I] = range(11)  # object_info tuple
         biom_obj_ref = str(new_obj_info[WSID_I])+'/'+str(new_obj_info[OBJID_I])+'/'+str(new_obj_info[VERSION_I])
 
@@ -321,7 +321,7 @@ class OutputBuilder(object):
         extra_bucket_order = []
         sample_order = []
         classified_frac = []
-        
+
         # parse summary
         for input_reads_item in options['input_reads']:
             sample_order.append(input_reads_item['name'])
@@ -354,7 +354,7 @@ class OutputBuilder(object):
         # make plots
         if options['plot_type'] == 'bar':
             basename_ext = '-stacked_bar_plot'
-            return self._create_bar_plots (out_folder = options['stacked_plots_out_folder'], 
+            return self._create_bar_plots (out_folder = options['stacked_plots_out_folder'],
                                            out_file_basename = tax_level+basename_ext,
                                            vals = abundance_matrix,
                                            frac_vals = classified_frac,
@@ -362,12 +362,12 @@ class OutputBuilder(object):
                                            title = tax_level.title(),
                                            frac_y_label = 'fraction classified',
                                            y_label = 'percent of classified reads',
-                                           sample_labels = sample_order, 
-                                           element_labels = lineage_order, 
+                                           sample_labels = sample_order,
+                                           element_labels = lineage_order,
                                            sort_by = options['sort_taxa_by'])
         elif options['plot_type'] == 'area':
             basename_ext = '-stacked_area_plot'
-            return self._create_area_plots (out_folder = options['stacked_plots_out_folder'], 
+            return self._create_area_plots (out_folder = options['stacked_plots_out_folder'],
                                            out_file_basename = tax_level+basename_ext,
                                            vals = abundance_matrix,
                                            frac_vals = classified_frac,
@@ -375,8 +375,8 @@ class OutputBuilder(object):
                                            title = tax_level.title(),
                                            frac_y_label = 'fraction classified',
                                            y_label = 'percent of classified reads',
-                                           sample_labels = sample_order, 
-                                           element_labels = lineage_order, 
+                                           sample_labels = sample_order,
+                                           element_labels = lineage_order,
                                            sort_by = options['sort_taxa_by'])
         else:
             raise ValueError ("Unknown plot type "+options['plot_type'])
@@ -384,7 +384,7 @@ class OutputBuilder(object):
 
     def generate_kaijuReport_StackedAreaPlots(self, options):
         pass
-        
+
 
     def build_html_for_kaijuReport_StackedPlots(self, input_reads, summary_folder, out_html_folder, plot_type, tax_levels, img_files):
         img_height = 750  # in pixels
@@ -395,7 +395,7 @@ class OutputBuilder(object):
         if not os.path.exists(out_html_img_path):
             os.makedirs(out_html_img_path)
         out_html_file = None
-        out_html_buf = []        
+        out_html_buf = []
 
         # add header
         plot_type_disp = plot_type.title()
@@ -407,7 +407,7 @@ class OutputBuilder(object):
             dst_local_path = os.path.join (img_local_path, plot_type+'-'+tax_level+'.PNG')
             dst_plot_file = os.path.join (out_html_folder, dst_local_path)
             shutil.copy2 (src_plot_file, dst_plot_file)
-            
+
             # increase height if key is long
             lineage_seen = dict()
             for input_reads_item in input_reads:
@@ -415,7 +415,7 @@ class OutputBuilder(object):
                 (this_abundance, this_lineage_order, this_classified_frac) = self._parse_kaiju_summary_file (this_summary_file, tax_level)
                 for lineage_name in this_lineage_order:
                     lineage_seen[lineage_name] = True
-            
+
             len_key = len(lineage_seen.keys())
             if key_scale * len_key > img_height:
                 this_img_height = key_scale * len_key
@@ -427,7 +427,7 @@ class OutputBuilder(object):
 
         # add footer
         out_html_buf.extend (self._build_plot_html_footer())
-        
+
         # write file
         out_local_path = plot_type+'.html'
         out_html_path = os.path.join (out_html_folder, out_local_path)
@@ -438,7 +438,7 @@ class OutputBuilder(object):
                          'local_path': out_local_path,
                          'abs_path': out_html_path
                      }
-        
+
         return [out_html_file]
 
 
@@ -458,7 +458,7 @@ class OutputBuilder(object):
 
             # copy plot imgs to html folder and add img to html page
             for input_reads_item in options['input_reads']:
-                sample_name = input_reads_item['name']            
+                sample_name = input_reads_item['name']
                 src_plot_file = img_files[tax_level][sample_name]
                 dst_local_path = os.path.join (img_local_path, 'per_sample_abundance-'+tax_level+'-'+sample_name+'.PNG')
                 dst_plot_file = os.path.join (out_html_folder, dst_local_path)
@@ -468,7 +468,7 @@ class OutputBuilder(object):
 
             # add footer
             out_html_buf.extend (self._build_plot_html_footer())
-        
+
             # write file
             out_local_path = 'per_sample_abundance-'+tax_level+'.html'
             out_html_path = os.path.join (out_html_folder, out_local_path)
@@ -478,7 +478,7 @@ class OutputBuilder(object):
                                    'name': tax_level,
                                    'local_path': out_local_path,
                                    'abs_path': out_html_path})
-                                      
+
         return out_html_files
 
 
@@ -749,15 +749,15 @@ class OutputBuilder(object):
         return (abundance_cnts, lineage_order)
 
 
-    def _create_bar_plots (self, out_folder=None, 
-                           out_file_basename=None, 
-                           vals=None, 
+    def _create_bar_plots (self, out_folder=None,
+                           out_file_basename=None,
+                           vals=None,
                            frac_vals=None,
-                           title=None, 
+                           title=None,
                            frac_y_label=None,
-                           y_label=None, 
-                           sample_labels=None, 
-                           element_labels=None, 
+                           y_label=None,
+                           sample_labels=None,
+                           element_labels=None,
                            sort_by=None):
 
         # DEBUG
@@ -793,7 +793,7 @@ class OutputBuilder(object):
                 color_names[label_i] = 'magenta'
             elif label.startswith('unassigned at'):
                 color_names[label_i] = 'darkslategray'
-                
+
 
         # Sort vals
         if sort_by != None:
@@ -807,7 +807,7 @@ class OutputBuilder(object):
             # alphabet sort
             if sort_by == 'alpha':
                 new_label_i = 0
-                for label in sorted(element_labels, reverse=True):                
+                for label in sorted(element_labels, reverse=True):
                     if label.startswith('tail (<') or label.startswith('viruses') or label.startswith('unassigned at'):
                         new_index[label] = old_index[label]
                     else:
@@ -836,10 +836,10 @@ class OutputBuilder(object):
                             new_index[label] = old_index[label]
                         else:
                             new_index[label] = new_label_i
-                            new_label_i += 1       
+                            new_label_i += 1
                         #print ("LABEL: "+str(label)+" NEW_INDEX: "+str(new_index[label]))  # DEBUG
 
-            # store new order            
+            # store new order
             new_vals = []
             new_element_labels = []
             for label_i,label in enumerate(element_labels):
@@ -862,7 +862,7 @@ class OutputBuilder(object):
         element_labels = element_labels[-4::-1] + element_labels[-3:]
         vals = vals[-4::-1] + vals[-3:]
 
-    
+
         # plot dimensions
         #per_unit_to_inch_scale = 0.25
         per_unit_to_inch_scale = 0.5
@@ -875,7 +875,7 @@ class OutputBuilder(object):
             plot_width_unit = 2*plot_x_pad_unit + downscale_above_N + extra_sample_scale*(N-downscale_above_N)
         plot_height_unit = 8
 
-        
+
         # label dimensions
         longest_sample_label_len = 0
         longest_element_label_len = 0
@@ -915,7 +915,7 @@ class OutputBuilder(object):
         # instantiate fig
         #
         # lose axes with below grid, and so sharex property. instead match xlim, bar_width, hide ticks.
-        #fig, (ax_top, ax_bot) = plt.subplots(2, 1, sharex=True)  
+        #fig, (ax_top, ax_bot) = plt.subplots(2, 1, sharex=True)
 
         # gridspec_kw not in KBase docker notebook agg image (old python?)
         #fig, (ax_top, ax_bot) = plt.subplots(2, 1, sharex=True, gridspec_kw = {'height_ratios':[1, 3]})
@@ -954,7 +954,7 @@ class OutputBuilder(object):
         np_vals = []
         for vec_i,val_vec in enumerate(vals):
             np_vals.append(np.array(val_vec))
-        
+
 
         # plot fraction measured
         frac = ax_top.bar(ind, frac_vals, bar_width_unit, color='black', alpha=0.5, ec='none')
@@ -991,7 +991,7 @@ class OutputBuilder(object):
         ax_bot.set_yticks(np.arange(0, 101, 20))
         ax_bot.set_ylim([0,100])
         ax_bot.set_xlim([-plot_x_pad_unit,N-plot_x_pad_unit])
-        
+
 
         # are positions now in units (btw. 0-1) or inches?  seems to depend on the backend Agg
         x_pad = x_pad_unit / canvas_width_unit
@@ -1006,13 +1006,13 @@ class OutputBuilder(object):
         # don't shrink frac plot.  instead place it explictly since we built canvas for it
         #
         box = ax_top.get_position()
-#        ax_top.set_position([box.x0 + x_pad_inch, 
-#                             box.y0 + y_pad_inch, 
-#                             box.width - x_label_pad_inch - 2*x_pad_inch, 
+#        ax_top.set_position([box.x0 + x_pad_inch,
+#                             box.y0 + y_pad_inch,
+#                             box.width - x_label_pad_inch - 2*x_pad_inch,
 #                             #box.height - y_pad_inch
 #                             box.height
 #                         ])
-        top_pos = [x_0, y_0, w, h] = [0 + x_pad, 
+        top_pos = [x_0, y_0, w, h] = [0 + x_pad,
                                       (1.0 - top_frac)*plot_height + y_label_pad,
                                       plot_width,
                                       top_frac*plot_height - 2*y_pad
@@ -1030,14 +1030,14 @@ class OutputBuilder(object):
         #   don't shrink plot.  instead place it explictly since we built canvas for it
         #
         box = ax_bot.get_position()
-        #ax_bot.set_position([box.x0 + x_pad_inch, 
-        #                     #box.y0 + y_pad_inch + y_label_pad_inch, 
+        #ax_bot.set_position([box.x0 + x_pad_inch,
+        #                     #box.y0 + y_pad_inch + y_label_pad_inch,
         #                     box.y0,
-        #                     box.width - x_label_pad_inch - 2*x_pad_inch, 
+        #                     box.width - x_label_pad_inch - 2*x_pad_inch,
         #                     #box.height - y_label_pad_inch - y_pad_inch
         #                     box.height
         #                 ])
-        bot_pos = [x_0, y_0, w, h] = [0 + x_pad, 
+        bot_pos = [x_0, y_0, w, h] = [0 + x_pad,
                                       0 + y_label_pad + y_pad,
                                       plot_width,
                                       (1.0 - top_frac)*plot_height - 2*y_pad
@@ -1068,19 +1068,19 @@ class OutputBuilder(object):
         output_pdf_file_path = os.path.join(out_folder, pdf_file);
         fig.savefig(output_png_file_path, dpi=img_dpi)
         fig.savefig(output_pdf_file_path, format='pdf')
-        
+
         return output_png_file_path
 
 
-    def _create_area_plots (self, out_folder=None, 
-                           out_file_basename=None, 
-                           vals=None, 
+    def _create_area_plots (self, out_folder=None,
+                           out_file_basename=None,
+                           vals=None,
                            frac_vals=None,
-                           title=None, 
+                           title=None,
                            frac_y_label=None,
-                           y_label=None, 
-                           sample_labels=None, 
-                           element_labels=None, 
+                           y_label=None,
+                           sample_labels=None,
+                           element_labels=None,
                            sort_by=None):
 
         # number of samples
@@ -1102,7 +1102,7 @@ class OutputBuilder(object):
                 color_names[label_i] = 'magenta'
             elif label.startswith('unassigned at'):
                 color_names[label_i] = 'darkslategray'
-                
+
 
         # Sort vals
         if sort_by != None:
@@ -1116,7 +1116,7 @@ class OutputBuilder(object):
             # alphabet sort
             if sort_by == 'alpha':
                 new_label_i = 0
-                for label in sorted(element_labels, reverse=True):                
+                for label in sorted(element_labels, reverse=True):
                     if label.startswith('tail (<') or label.startswith('viruses') or label.startswith('unassigned at'):
                         new_index[label] = old_index[label]
                     else:
@@ -1145,10 +1145,10 @@ class OutputBuilder(object):
                             new_index[label] = old_index[label]
                         else:
                             new_index[label] = new_label_i
-                            new_label_i += 1       
+                            new_label_i += 1
                         #print ("LABEL: "+str(label)+" NEW_INDEX: "+str(new_index[label]))  # DEBUG
 
-            # store new order            
+            # store new order
             new_vals = []
             new_element_labels = []
             for label_i,label in enumerate(element_labels):
@@ -1171,7 +1171,7 @@ class OutputBuilder(object):
         element_labels = element_labels[-4::-1] + element_labels[-3:]
         vals = vals[-4::-1] + vals[-3:]
 
-    
+
         # plot dimensions
         #per_unit_to_inch_scale = 0.25
         per_unit_to_inch_scale = 0.5
@@ -1184,7 +1184,7 @@ class OutputBuilder(object):
             plot_width_unit = 2*plot_x_pad_unit + downscale_above_N + extra_sample_scale*(N-downscale_above_N)
         plot_height_unit = 8
 
-        
+
         # label dimensions
         longest_sample_label_len = 0
         longest_element_label_len = 0
@@ -1224,7 +1224,7 @@ class OutputBuilder(object):
         # instantiate fig
         #
         # lose axes with below grid, and so sharex property. instead match xlim, bar_width, hide ticks.
-        #fig, (ax_top, ax_bot) = plt.subplots(2, 1, sharex=True)  
+        #fig, (ax_top, ax_bot) = plt.subplots(2, 1, sharex=True)
 
         # gridspec_kw not in KBase docker notebook agg image (old python?)
         #fig, (ax_top, ax_bot) = plt.subplots(2, 1, sharex=True, gridspec_kw = {'height_ratios':[1, 3]})
@@ -1263,7 +1263,7 @@ class OutputBuilder(object):
         np_vals = []
         for vec_i,val_vec in enumerate(vals):
             np_vals.append(np.array(val_vec))
-        
+
 
         # plot fraction measured
         frac = ax_top.bar(ind, frac_vals, bar_width_unit, color='black', alpha=0.5, ec='none')
@@ -1289,7 +1289,7 @@ class OutputBuilder(object):
         for color_i in reversed(np.arange(N-1)):
             key_colors.append(mpatches.Patch(color=color_names[color_i], alpha=0.5, ec='black'))
         box = ax.get_position()
-        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])   
+        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
         plt.legend(key_colors, reversed(element_labels), loc='upper left', bbox_to_anchor=(1, 1))
         """
 
@@ -1309,7 +1309,7 @@ class OutputBuilder(object):
         ax_bot.set_yticks(np.arange(0, 101, 20))
         ax_bot.set_ylim([0,100])
         ax_bot.set_xlim([-plot_x_pad_unit,N-plot_x_pad_unit])
-        
+
 
         # are positions now in units (btw. 0-1) or inches?  seems to depend on the backend Agg
         x_pad = x_pad_unit / canvas_width_unit
@@ -1324,13 +1324,13 @@ class OutputBuilder(object):
         # don't shrink frac plot.  instead place it explictly since we built canvas for it
         #
         box = ax_top.get_position()
-#        ax_top.set_position([box.x0 + x_pad_inch, 
-#                             box.y0 + y_pad_inch, 
-#                             box.width - x_label_pad_inch - 2*x_pad_inch, 
+#        ax_top.set_position([box.x0 + x_pad_inch,
+#                             box.y0 + y_pad_inch,
+#                             box.width - x_label_pad_inch - 2*x_pad_inch,
 #                             #box.height - y_pad_inch
 #                             box.height
 #                         ])
-        top_pos = [x_0, y_0, w, h] = [0 + x_pad, 
+        top_pos = [x_0, y_0, w, h] = [0 + x_pad,
                                       (1.0 - top_frac)*plot_height + y_label_pad,
                                       plot_width,
                                       top_frac*plot_height - 2*y_pad
@@ -1348,14 +1348,14 @@ class OutputBuilder(object):
         #   don't shrink plot.  instead place it explictly since we built canvas for it
         #
         box = ax_bot.get_position()
-        #ax_bot.set_position([box.x0 + x_pad_inch, 
-        #                     #box.y0 + y_pad_inch + y_label_pad_inch, 
+        #ax_bot.set_position([box.x0 + x_pad_inch,
+        #                     #box.y0 + y_pad_inch + y_label_pad_inch,
         #                     box.y0,
-        #                     box.width - x_label_pad_inch - 2*x_pad_inch, 
+        #                     box.width - x_label_pad_inch - 2*x_pad_inch,
         #                     #box.height - y_label_pad_inch - y_pad_inch
         #                     box.height
         #                 ])
-        bot_pos = [x_0, y_0, w, h] = [0 + x_pad, 
+        bot_pos = [x_0, y_0, w, h] = [0 + x_pad,
                                       0 + y_label_pad + y_pad,
                                       plot_width,
                                       (1.0 - top_frac)*plot_height - 2*y_pad
@@ -1383,9 +1383,9 @@ class OutputBuilder(object):
         for color_i in reversed(np.arange(N-1)):
             key_colors.append(mpatches.Patch(color=color_names[color_i], alpha=0.5, ec='black'))
         box = ax_top.get_position()
-        ax_top.set_position([box.x0, box.y0, box.width * w_scale, box.height])   
+        ax_top.set_position([box.x0, box.y0, box.width * w_scale, box.height])
         box = ax_bot.get_position()
-        ax_bot.set_position([box.x0, box.y0, box.width * w_scale, box.height])   
+        ax_bot.set_position([box.x0, box.y0, box.width * w_scale, box.height])
         ax_bot.legend(key_colors, reversed(element_labels), loc='upper left', bbox_to_anchor=(1, 1))
 
 
@@ -1399,7 +1399,7 @@ class OutputBuilder(object):
         output_pdf_file_path = os.path.join(out_folder, pdf_file);
         fig.savefig(output_png_file_path, dpi=img_dpi)
         fig.savefig(output_pdf_file_path, format='pdf')
-        
+
         return output_png_file_path
 
 
@@ -1407,13 +1407,13 @@ class OutputBuilder(object):
 
     def _create_area_plots_OLD (self, abundances):
         color_names = self.no_light_color_names
-        
+
         import numpy as np
         import matplotlib.pyplot as plt
         import matplotlib.patches as mpatches
         import random
         from random import shuffle
-        
+
         y_label = 'percent'
         title = 'Lineage Proportion'
         sample_labels = ['sample1', 'sample2', 'sample3', 'sample4', 'sample5']
@@ -1436,7 +1436,7 @@ class OutputBuilder(object):
         np_vals = []
         for vec_i,val_vec in enumerate(vals):
             np_vals.append(np.array(val_vec))
-    
+
         # Build image
         if N < 10:
             img_in_width = 2*N
@@ -1472,7 +1472,7 @@ class OutputBuilder(object):
         for color_i in reversed(np.arange(N-1)):
             key_colors.append(mpatches.Patch(color=color_names[color_i], alpha=0.5, ec='black'))
         box = ax.get_position()
-        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])   
+        ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
         plt.legend(key_colors, reversed(element_labels), loc='upper left', bbox_to_anchor=(1, 1))
 
         #plt.grid()

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -22,29 +22,29 @@ elif [ "${1}" = "init" ] ; then
   cd /data/kaijudb
 
   echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_refseq_2019-06-25.tgz"
-  mkdir -p /data/kaijudb/kaiju_db_refseq_2019-06-25
-  cd /data/kaijudb/kaiju_db_refseq_2019-06-25
+  mkdir -p /data/kaijudb/
+  cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_refseq_2019-06-25.tgz
   tar -xzf kaiju_db_refseq_2019-06-25.tgz
   rm kaiju_db_refseq_2019-06-25.tgz
 
   echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_progenomes_2019-06-25.tgz"
-  mkdir -p /data/kaijudb/kaiju_db_progenomes_2019-06-25
-  cd /data/kaijudb/kaiju_db_progenomes_2019-06-25
+  mkdir -p /data/kaijudb/
+  cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_progenomes_2019-06-25.tgz
   tar -xzf kaiju_db_progenomes_2019-06-25.tgz
   rm kaiju_db_progenomes_2019-06-25.tgz
 
   echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_nr_2019-06-25.tgz"
-  mkdir -p /data/kaijudb/kaiju_db_nr_2019-06-25
-  cd /data/kaijudb/kaiju_db_nr_2019-06-25
+  mkdir -p /data/kaijudb/
+  cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_nr_2019-06-25.tgz
   tar -xzf kaiju_db_nr_2019-06-25.tgz
   rm kaiju_db_nr_2019-06-25.tgz
 
   echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_nr_euk_2019-06-25.tgz"
-  mkdir -p /data/kaijudb/kaiju_db_nr_euk_2019-06-25
-  cd /data/kaijudb/kaiju_db_nr_euk_2019-06-25
+  mkdir -p /data/kaijudb/
+  cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_nr_euk_2019-06-25.tgz
   tar -xzf kaiju_db_nr_euk_2019-06-25.tgz
   rm kaiju_db_nr_euk_2019-06-25.tgz
@@ -52,7 +52,7 @@ elif [ "${1}" = "init" ] ; then
   cd /data/kaijudb
 #  if [ -s "/data/kaijudb/kaiju_index/kaiju_db.fmi" ] ; then
 #  if [ -s "/data/kaijudb/kaiju_index/kaiju_db.fmi" -eq 15851683711 -a -s "/data/kaijudb/kaiju_index_pg/kaiju_db.fmi" -eq 12737853741 -a -s "/data/kaijudb/kaiju_index_nr/kaiju_db_nr.fmi" -eq 45220614796 -a -s "/data/kaijudb/kaiju_index_nr_euk/kaiju_db_nr_euk.fmi" -eq 51503967892 ] ; then
-  if [ -s "/data/kaijudb/kaiju_index/kaiju_db.fmi" -a -s "/data/kaijudb/kaiju_db_progenomes_2019-06-25/progenomes/kaiju_db_progenomes.fmi" -a -s "/data/kaijudb/kaiju_index_nr/kaiju_db_nr.fmi" -a -s "/data/kaijudb/kaiju_index_nr_euk/kaiju_db_nr_euk.fmi" ] ; then
+  if [ -s "/data/kaijudb/refseq/kaiju_db_refseq.fmi" -a -s "/data/kaijudb/progenomes/kaiju_db_progenomes.fmi" -a -s "/data/kaijudb/nr/kaiju_db_nr.fmi" -a -s "/data/kaijudb/nr_euk/kaiju_db_nr_euk.fmi" ] ; then
     echo "DATA DOWNLOADED SUCCESSFULLY"
     touch /data/__READY__
   else

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -26,6 +26,8 @@ elif [ "${1}" = "init" ] ; then
   cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_refseq_2019-06-25.tgz
   tar -xzf kaiju_db_refseq_2019-06-25.tgz
+  mv names.dmp refseq/names.dmp
+  mv nodes.dmp refseq/nodes.dmp
   rm kaiju_db_refseq_2019-06-25.tgz
 
   echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_progenomes_2019-06-25.tgz"
@@ -33,6 +35,8 @@ elif [ "${1}" = "init" ] ; then
   cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_progenomes_2019-06-25.tgz
   tar -xzf kaiju_db_progenomes_2019-06-25.tgz
+  mv names.dmp progenomes/names.dmp
+  mv nodes.dmp progenomes/nodes.dmp
   rm kaiju_db_progenomes_2019-06-25.tgz
 
   echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_nr_2019-06-25.tgz"
@@ -40,6 +44,8 @@ elif [ "${1}" = "init" ] ; then
   cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_nr_2019-06-25.tgz
   tar -xzf kaiju_db_nr_2019-06-25.tgz
+  mv names.dmp nr/names.dmp
+  mv nodes.dmp nr/nodes.dmp
   rm kaiju_db_nr_2019-06-25.tgz
 
   echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_nr_euk_2019-06-25.tgz"
@@ -47,6 +53,8 @@ elif [ "${1}" = "init" ] ; then
   cd /data/kaijudb/
   wget -q http://kaiju.binf.ku.dk/database/kaiju_db_nr_euk_2019-06-25.tgz
   tar -xzf kaiju_db_nr_euk_2019-06-25.tgz
+  mv names.dmp nr_euk/names.dmp
+  mv nodes.dmp nr_euk/nodes.dmp
   rm kaiju_db_nr_euk_2019-06-25.tgz
 
   cd /data/kaijudb

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,43 +21,43 @@ elif [ "${1}" = "init" ] ; then
   mkdir -p /data/kaijudb
   cd /data/kaijudb
 
-  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_index.tgz"
-  mkdir -p /data/kaijudb/kaiju_index
-  cd /data/kaijudb/kaiju_index
-  wget -q http://kaiju.binf.ku.dk/database/kaiju_index.tgz
-  tar -xzf kaiju_index.tgz
-  rm kaiju_index.tgz
+  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_refseq_2019-06-25.tgz"
+  mkdir -p /data/kaijudb/kaiju_db_refseq_2019-06-25
+  cd /data/kaijudb/kaiju_db_refseq_2019-06-25
+  wget -q http://kaiju.binf.ku.dk/database/kaiju_db_refseq_2019-06-25.tgz
+  tar -xzf kaiju_db_refseq_2019-06-25.tgz
+  rm kaiju_db_refseq_2019-06-25.tgz
 
-  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_index_pg.tgz"
-  mkdir -p /data/kaijudb/kaiju_index_pg
-  cd /data/kaijudb/kaiju_index_pg
-  wget -q http://kaiju.binf.ku.dk/database/kaiju_index_pg.tgz
-  tar -xzf kaiju_index_pg.tgz
-  rm kaiju_index_pg.tgz
+  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_progenomes_2019-06-25.tgz"
+  mkdir -p /data/kaijudb/kaiju_db_progenomes_2019-06-25
+  cd /data/kaijudb/kaiju_db_progenomes_2019-06-25
+  wget -q http://kaiju.binf.ku.dk/database/kaiju_db_progenomes_2019-06-25.tgz
+  tar -xzf kaiju_db_progenomes_2019-06-25.tgz
+  rm kaiju_db_progenomes_2019-06-25.tgz
 
-  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_index_nr.tgz"
-  mkdir -p /data/kaijudb/kaiju_index_nr
-  cd /data/kaijudb/kaiju_index_nr
-  wget -q http://kaiju.binf.ku.dk/database/kaiju_index_nr.tgz
-  tar -xzf kaiju_index_nr.tgz
-  rm kaiju_index_nr.tgz
+  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_nr_2019-06-25.tgz"
+  mkdir -p /data/kaijudb/kaiju_db_nr_2019-06-25
+  cd /data/kaijudb/kaiju_db_nr_2019-06-25
+  wget -q http://kaiju.binf.ku.dk/database/kaiju_db_nr_2019-06-25.tgz
+  tar -xzf kaiju_db_nr_2019-06-25.tgz
+  rm kaiju_db_nr_2019-06-25.tgz
 
-  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_index_nr_euk.tgz"
-  mkdir -p /data/kaijudb/kaiju_index_nr_euk
-  cd /data/kaijudb/kaiju_index_nr_euk
-  wget -q http://kaiju.binf.ku.dk/database/kaiju_index_nr_euk.tgz
-  tar -xzf kaiju_index_nr_euk.tgz
-  rm kaiju_index_nr_euk.tgz
+  echo "downloading: http://kaiju.binf.ku.dk/database/kaiju_db_nr_euk_2019-06-25.tgz"
+  mkdir -p /data/kaijudb/kaiju_db_nr_euk_2019-06-25
+  cd /data/kaijudb/kaiju_db_nr_euk_2019-06-25
+  wget -q http://kaiju.binf.ku.dk/database/kaiju_db_nr_euk_2019-06-25.tgz
+  tar -xzf kaiju_db_nr_euk_2019-06-25.tgz
+  rm kaiju_db_nr_euk_2019-06-25.tgz
 
   cd /data/kaijudb
 #  if [ -s "/data/kaijudb/kaiju_index/kaiju_db.fmi" ] ; then
 #  if [ -s "/data/kaijudb/kaiju_index/kaiju_db.fmi" -eq 15851683711 -a -s "/data/kaijudb/kaiju_index_pg/kaiju_db.fmi" -eq 12737853741 -a -s "/data/kaijudb/kaiju_index_nr/kaiju_db_nr.fmi" -eq 45220614796 -a -s "/data/kaijudb/kaiju_index_nr_euk/kaiju_db_nr_euk.fmi" -eq 51503967892 ] ; then
-  if [ -s "/data/kaijudb/kaiju_index/kaiju_db.fmi" -a -s "/data/kaijudb/kaiju_index_pg/kaiju_db.fmi" -a -s "/data/kaijudb/kaiju_index_nr/kaiju_db_nr.fmi" -a -s "/data/kaijudb/kaiju_index_nr_euk/kaiju_db_nr_euk.fmi" ] ; then
+  if [ -s "/data/kaijudb/kaiju_index/kaiju_db.fmi" -a -s "/data/kaijudb/kaiju_db_progenomes_2019-06-25/progenomes/kaiju_db_progenomes.fmi" -a -s "/data/kaijudb/kaiju_index_nr/kaiju_db_nr.fmi" -a -s "/data/kaijudb/kaiju_index_nr_euk/kaiju_db_nr_euk.fmi" ] ; then
     echo "DATA DOWNLOADED SUCCESSFULLY"
     touch /data/__READY__
   else
     echo "Init failed"
-  fi  
+  fi
 elif [ "${1}" = "bash" ] ; then
   bash
 elif [ "${1}" = "report" ] ; then

--- a/test/kaiju_example.sh
+++ b/test/kaiju_example.sh
@@ -13,20 +13,20 @@ KAIJU2KRONA_BIN=$KAIJU_BINDIR/kaiju2krona
 KRONAIMPORT_BIN=$KRONA_BINDIR/ktImportText
 
 KAIJU_DBDIR=$HOME/proj/SDK/sdk_modules/kb_kaiju/data/kaijudb
-KAIJU_DBTYPE=kaiju_index
-#KAIJU_DBTYPE=kaiju_index_pg
-#KAIJU_DBTYPE=kaiju_index_nr
-#KAIJU_DBTYPE=kaiju_index_nr_euk
+KAIJU_DBTYPE=refseq
+#KAIJU_DBTYPE=progenomes
+#KAIJU_DBTYPE=nr
+#KAIJU_DBTYPE=nr_euk
 KAIJU_NODES=$KAIJU_DBDIR/$KAIJU_DBTYPE/nodes.dmp
 KAIJU_NAMES=$KAIJU_DBDIR/$KAIJU_DBTYPE/names.dmp
 
-if [ $KAIJU_DBTYPE = "kaiju_index" ] ; then
-    KAIJU_DBPATH=$KAIJU_DBDIR/$KAIJU_DBTYPE/kaiju_db.fmi
-elif [ $KAIJU_DBTYPE = "kaiju_index_pg" ] ; then
-    KAIJU_DBPATH=$KAIJU_DBDIR/$KAIJU_DBTYPE/kaiju_db.fmi
-elif [ $KAIJU_DBTYPE = "kaiju_index_nr" ] ; then
+if [ $KAIJU_DBTYPE = "refseq" ] ; then
+    KAIJU_DBPATH=$KAIJU_DBDIR/$KAIJU_DBTYPE/kaiju_db_refseq.fmi
+elif [ $KAIJU_DBTYPE = "progenomes" ] ; then
+    KAIJU_DBPATH=$KAIJU_DBDIR/$KAIJU_DBTYPE/kaiju_db_progenomes.fmi
+elif [ $KAIJU_DBTYPE = "nr" ] ; then
     KAIJU_DBPATH=$KAIJU_DBDIR/$KAIJU_DBTYPE/kaiju_db_nr.fmi
-elif [ $KAIJU_DBTYPE = "kaiju_index_nr_euk" ] ; then
+elif [ $KAIJU_DBTYPE = "nr_euk" ] ; then
     KAIJU_DBPATH=$KAIJU_DBDIR/$KAIJU_DBTYPE/kaiju_db_nr_euk.fmi
 fi
 

--- a/test/kaiju_example.sh
+++ b/test/kaiju_example.sh
@@ -8,7 +8,7 @@ KRONA_HOME=$HOME/proj/SDK/sdk_modules/kb_kaiju/bin/Krona
 KRONA_BINDIR=$KRONA_HOME/bin/bin
 
 KAIJU_BIN=$KAIJU_BINDIR/kaiju
-KAIJU_REPORT_BIN=$KAIJU_BINDIR/kaijuReport
+KAIJU_REPORT_BIN=$KAIJU_BINDIR/kaiju2table
 KAIJU2KRONA_BIN=$KAIJU_BINDIR/kaiju2krona
 KRONAIMPORT_BIN=$KRONA_BINDIR/ktImportText
 
@@ -77,10 +77,10 @@ if [ $filter_perc -gt 0 ] ; then
 else
     filter_arg=$filter_unclassified
 fi
-cmd="$KAIJU_REPORT_BIN -t $KAIJU_NODES -n $KAIJU_NAMES -i $kaiju_out_file -r $tax_level $filter_arg $taxon_fullpath_arg -o $kaiju_summary_out_file"
+cmd="$KAIJU_REPORT_BIN -t $KAIJU_NODES -n $KAIJU_NAMES -r $tax_level $filter_arg $taxon_fullpath_arg -o $kaiju_summary_out_file $kaiju_out_file"
 if [ ! -s $kaiju_summary_out_file ] ; then
     echo
-    echo $cmd 
+    echo $cmd
     exec $cmd
 fi
 

--- a/test/kaiju_example.sh
+++ b/test/kaiju_example.sh
@@ -58,7 +58,7 @@ if [ -s rev_reads ] ; then
 else
     rev_reads_arg=""
 fi
-cmd="$KAIJU_BIN -t $KAIJU_NODES -f $KAIJU_DBPATH $fwd_reads_arg $rev_reads_arg -o $kaiju_out_file $SEG_filter $minlength $minscore $greedy $mismatches $e_value $threads $verbose"
+cmd="$KAIJU_BIN -t $KAIJU_NODES -f $KAIJU_DBPATH -i $fwd_reads_arg -j $rev_reads_arg -o $kaiju_out_file $SEG_filter $minlength $minscore $greedy $mismatches $e_value $threads $verbose"
 if [ ! -s $kaiju_out_file ] ; then
     echo $cmd
     exec $cmd

--- a/test/kb_kaiju_server_test.py
+++ b/test/kb_kaiju_server_test.py
@@ -195,14 +195,14 @@ class kb_kaijuTest(unittest.TestCase):
         # run kaiju
         #input_refs = [self.PE_reads_refs[0]]
         input_refs = [self.PE_reads_refs[0], self.PE_reads_refs[1]]
-        #output_biom_name = 'test_kb_kaiju_test1.BIOM'        
+        #output_biom_name = 'test_kb_kaiju_test1.BIOM'
         params = {
             'workspace_name':            self.ws_info[1],
             'input_refs':                input_refs,
             #'output_biom_name':          output_biom_name,
             'tax_levels':                ['phylum','genus'],
             #'tax_levels':                ['phylum'],
-            'db_type':                   'kaiju_index',  
+            'db_type':                   'refseq',
             #'filter_percent':            1,
             'filter_percent':            0.5,
             #'subsample_percent':         100,
@@ -250,14 +250,14 @@ class kb_kaijuTest(unittest.TestCase):
         # run kaiju
         #input_refs = [self.SE_reads_refs[0]]
         input_refs = [self.SE_reads_refs[0], self.SE_reads_refs[1]]
-        #output_biom_name = 'test_kb_kaiju_test2.BIOM'        
+        #output_biom_name = 'test_kb_kaiju_test2.BIOM'
         params = {
             'workspace_name':            self.ws_info[1],
             'input_refs':                input_refs,
             #'output_biom_name':          output_biom_name,
             'tax_levels':                ['phylum','genus'],
             #'tax_levels':                ['phylum'],
-            'db_type':                   'kaiju_index',  
+            'db_type':                   'refseq',
             #'filter_percent':            1,
             'filter_percent':            0.5,
             #'subsample_percent':         100,

--- a/ui/narrative/methods/run_kaiju/spec.json
+++ b/ui/narrative/methods/run_kaiju/spec.json
@@ -2,7 +2,7 @@
 	"ver": "1.0.4",
 
 	"authors": [
-		"dylan"
+		"dylan","seanjungbluth"
 	],
 	"contact": "http://kbase.us/contact-us/",
 	"visible": true,


### PR DESCRIPTION
From RELEASE_NOTES.md

### Version 1.0.7
__Changes__
- updated Kaiju reference databases; now using 2019-06-25 versions
- added new required flags -i and -j to kaiju binary
- renamed kaijuReport binary to kaiju2table
- removed discontinued flag -i from kaiju2table
- addressed new kaiju database directory structure
