### PR TITLE
v1.2.1 When building, update root certificiates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,11 @@ RUN pip install coverage
 
 # Install xvfb for matplotlib pdfs
 #    apt-get -y install xvfb
-RUN apt-get update && \
-    apt-get -y install xvfb python-qt4
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN sed -i 's/\(.*DST_Root_CA_X3.crt\)/!\1/' /etc/ca-certificates.conf
+RUN update-ca-certificates
+RUN apt-get -y install xvfb python-qt4
 
 
 # For kaiju bin

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+### Version 1.2.1
+__Changes__
+- update root certificates so that refdata downloads correctly see:
+    https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
+
 ### Version 1.2.0
 __Changes__
 - updated to early 2021 database releases (range of dates)

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.2.0
+    1.2.1
 
 owners:
     [dylan, seanjungbluth]


### PR DESCRIPTION
The certificates in the usual image are affected by the Let's Encrypt root CA expiration in September 2021. This causes the refdata load to fail. Updating the root certificate solves the issue. See the [Let's Encrypt announcement](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/) for more details on this event.